### PR TITLE
Removed extra comma in Default.sublime-commands

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -26,5 +26,5 @@
   {
     "caption": "Github: Pull Requests",
     "command": "github_pulls"
-  },
+  }
 ]


### PR DESCRIPTION
There was an extra comma in Default.sublime-commands that prevents loading the module.

```
Error loading commands: Error trying to parse file: Trailing comma before closing bracket in ~/.config/sublime-text-2/Packages/Github Tools/Default.sublime-commands:30:1
```
