### PR TITLE
Fix the remote URL in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,21 +31,21 @@ Use `Cmd` instead of `Ctrl` on Mac OS X.
 
 ```bash
 cd ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/
-git clone git://github.com/temochka/sublime-text-2-github.git
+git clone git://github.com/temochka/sublime-text-2-github-tools.git
 ```
 
 ### On Linux ###
 
 ```bash
 cd ~/.config/sublime-text-2/Packages/
-git clone git://github.com/temochka/sublime-text-2-github.git
+git clone git://github.com/temochka/sublime-text-2-github-tools.git
 ```
 
 ### On Windows ###
 
 ```
 cd %APPDATA%/Sublime Text 2/Packages/
-git clone git://github.com/temochka/sublime-text-2-github.git
+git clone git://github.com/temochka/sublime-text-2-github-tools.git
 ```
 
 Make sure you have included all required binaries (`git`) in your PATH.


### PR DESCRIPTION
Hello,

This is just a tiny pull request that changes the remote URL to this repository when we are installing through Git.

Thanks for this awesome project so far ; it's really handy to be able to type `Ctrl + P` and hit `gh open` to see the current file on GitHub! :heart:

Have a nice day.
