### PR TITLE
Fix urllib error for Python 2

### DIFF
--- a/github.py
+++ b/github.py
@@ -1,5 +1,8 @@
 import sublime, sublime_plugin, re, os, json
-import urllib.parse as urllib
+try:
+    import urllib.parse as urllib
+except ImportError:
+    import urllib
 from os.path import dirname, normpath, join
 from functools import wraps
 from pprint import pformat


### PR DESCRIPTION
With the default Python 2 that comes with MacOS 10.12 I was getting this error:

    Traceback (most recent call last):
      File "./sublime_plugin.py", line 62, in reload_plugin
      File "./github.py", line 2, in <module>
        import urllib.parse as urllib
    ImportError: No module named parse

And no `Github` commands would show up in the command palette.

I'm no Python expert so please examine closely.  My only Python 3 testing was via https://repl.it/languages/python3.

